### PR TITLE
Fix gson compatibility issues on 1.8 and clean up pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,19 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.17.1</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>2.17.1</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.9.0</version>
+            <scope>compile</scope>
         </dependency>
 	    <dependency>
 		    <groupId>com.meowj</groupId>
@@ -101,7 +108,7 @@
 	        <groupId>io.netty</groupId>
 	        <artifactId>netty-all</artifactId>
 	        <version>4.1.53.Final</version>
-	        <scope>compile</scope>
+	        <scope>provided</scope>
 	    </dependency>
         <dependency>
             <groupId>com.github.GeyserMC</groupId>
@@ -137,7 +144,6 @@
             </resource>
         </resources>
 
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -146,14 +152,6 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
-                <configuration>
-                    <outputDirectory>${dir}</outputDirectory>
                 </configuration>
             </plugin>
             <plugin>
@@ -168,6 +166,12 @@
                         </goals>
                         <configuration>
                             <minimizeJar>true</minimizeJar>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.gson</pattern>
+                                    <shadedPattern>me.dadus33.libs.gson</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>
@@ -176,9 +180,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.2.0</version>
-				<configuration>
-					<outputDirectory>${export_dir}</outputDirectory>
-				</configuration>
 			</plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.2.0</version>
+                <configuration>
+                    <outputDirectory>${export_dir}</outputDirectory>
+                </configuration>
 			</plugin>
         </plugins>
     </build>


### PR DESCRIPTION
shaded & relocated gson to fix incompatibility with the gson version a legacy server provides
also switched several dependencies that are provided by the server to `provided` and cleaned up maven-jar-plugin: the `<outputDirectory>${export_dir}</outputDirectory>` is unnecessary and the plugin was declared twice