### PR TITLE
Hot fix for hex-colored nicknames changed by Essentials-X

### DIFF
--- a/src/main/java/me/dadus33/chatitem/chatmanager/v2/ChatListener.java
+++ b/src/main/java/me/dadus33/chatitem/chatmanager/v2/ChatListener.java
@@ -232,6 +232,10 @@ public class ChatListener implements Listener {
 			} else if (waiting) { // if waiting for code and valid str
 				// if it's hexademical value and with enough space for full color
 				waiting = false;
+				if(args == 'r' && colorCode.isEmpty()) {
+					color = ChatColor.RESET;
+					continue;
+				}
 				if(args == 'x' && colorCode.isEmpty())
 					isHex = true;
 				colorCode += args; // a color by itself


### PR DESCRIPTION
After the general hex colors fix made by Elikill58 that fixed 99% of the problem, first character formatting still was off (as you can see on screenshot: https://media.discordapp.net/attachments/171243756849201153/946441326205993010/unknown.png), this was caused by §r added to the begining of the name. I fixed an error by adding check for char 'r' in showItem function (ChatListener.java : 235).