### PR TITLE
Fixed putting items from inventory to the GUI

### DIFF
--- a/src/main/java/me/dadus33/chatitem/listeners/InventoryListener.java
+++ b/src/main/java/me/dadus33/chatitem/listeners/InventoryListener.java
@@ -1,9 +1,12 @@
 package me.dadus33.chatitem.listeners;
 
-import static me.dadus33.chatitem.utils.ItemUtils.createItem;
-
-import java.util.Arrays;
-
+import me.dadus33.chatitem.ChatItem;
+import me.dadus33.chatitem.Storage;
+import me.dadus33.chatitem.Translation;
+import me.dadus33.chatitem.listeners.holder.AdminHolder;
+import me.dadus33.chatitem.listeners.holder.CustomInventoryHolder;
+import me.dadus33.chatitem.utils.ItemUtils;
+import me.dadus33.chatitem.utils.Messages;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -15,18 +18,23 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 
-import me.dadus33.chatitem.ChatItem;
-import me.dadus33.chatitem.Storage;
-import me.dadus33.chatitem.Translation;
-import me.dadus33.chatitem.listeners.holder.AdminHolder;
-import me.dadus33.chatitem.listeners.holder.CustomInventoryHolder;
-import me.dadus33.chatitem.utils.ItemUtils;
-import me.dadus33.chatitem.utils.Messages;
+import java.util.Arrays;
+
+import static me.dadus33.chatitem.utils.ItemUtils.createItem;
 
 public class InventoryListener implements Listener {
 
 	@EventHandler
 	public void onClick(InventoryClickEvent e) {
+		Player p = (Player) e.getWhoClicked();
+
+		InventoryHolder openInventoryHolder = p.getOpenInventory().getTopInventory().getHolder();
+
+		if (openInventoryHolder instanceof CustomInventoryHolder) {
+			e.setCancelled(true);
+			return;
+		}
+
 		if(e.getClickedInventory() == null || !(e.getWhoClicked() instanceof Player) || e.getCurrentItem() == null)
 			return;
 		InventoryHolder holder = e.getClickedInventory().getHolder();
@@ -39,7 +47,7 @@ public class InventoryListener implements Listener {
 		if(!(holder instanceof AdminHolder))
 			return;
 		e.setCancelled(true);
-		Player p = (Player) e.getWhoClicked();
+
 		ItemStack item = e.getCurrentItem();
 		Material type = item.getType();
 		Storage c = ChatItem.getInstance().getStorage();


### PR DESCRIPTION
When players open another player's inventory or ender chest, they can add items from their inventory to the GUI, but they can't take them back - they lose them.